### PR TITLE
bump build number to test pipeline

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpythonpython_implcpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpythonpython_implcpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_python3.8.____73_pypypython_implpypy.yaml
@@ -20,6 +20,8 @@ python_impl:
 - pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonpython_implcpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_python3.9.____73_pypypython_implpypy.yaml
@@ -20,6 +20,8 @@ python_impl:
 - pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpythonpython_implcpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpythonpython_implcpython.yaml
@@ -24,6 +24,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpythonpython_implcpython.yaml
@@ -24,6 +24,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____73_pypypython_implpypy.yaml
@@ -24,6 +24,8 @@ python_impl:
 - pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____cpythonpython_implcpython.yaml
@@ -24,6 +24,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____73_pypypython_implpypy.yaml
@@ -24,6 +24,8 @@ python_impl:
 - pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpythonpython_implcpython.yaml
@@ -24,6 +24,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpythonpython_implcpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpythonpython_implcpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____73_pypypython_implpypy.yaml
@@ -20,6 +20,8 @@ python_impl:
 - pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____cpythonpython_implcpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____73_pypypython_implpypy.yaml
@@ -20,6 +20,8 @@ python_impl:
 - pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____cpythonpython_implcpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/osx_64_python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpythonpython_implcpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpythonpython_implcpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_python3.8.____73_pypypython_implpypy.yaml
@@ -20,6 +20,8 @@ python_impl:
 - pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpythonpython_implcpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_python3.9.____73_pypypython_implpypy.yaml
@@ -20,6 +20,8 @@ python_impl:
 - pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpythonpython_implcpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -20,6 +20,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/win_64_python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpythonpython_implcpython.yaml
@@ -14,6 +14,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpythonpython_implcpython.yaml
@@ -14,6 +14,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/win_64_python3.8.____73_pypypython_implpypy.yaml
@@ -14,6 +14,8 @@ python_impl:
 - pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpythonpython_implcpython.yaml
@@ -14,6 +14,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/win_64_python3.9.____73_pypypython_implpypy.yaml
@@ -14,6 +14,8 @@ python_impl:
 - pypy
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpythonpython_implcpython.yaml
@@ -14,6 +14,8 @@ python_impl:
 - cpython
 rust_compiler:
 - rust
+rust_compiler_version:
+- 1.71.1
 target_platform:
 - win-64
 zip_keys:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+rust_compiler_version:
+  - 1.71.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
     # PyPy has weird sysconfigdata name
     - rm -f $PREFIX/lib/pypy$PY_VER/_sysconfigdata.py  # [build_platform != target_platform and target_platform == "linux-ppc64le"]
     - {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
i wanna see if pydantic-core 2.7.0 or conda-forge infra broke

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
